### PR TITLE
Adding socket timeout to client

### DIFF
--- a/assignment-5/test-client.py
+++ b/assignment-5/test-client.py
@@ -18,6 +18,7 @@ if not (len(sys.argv) == 3):
 
 # Create a TCP/IP socket
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(2.0)
 
 # Connect the socket to the port where the server is listening
 server_address = (sys.argv[1], int(sys.argv[2]))


### PR DESCRIPTION
This will prevent the client to wait forever in some rare cases when firewall is blocking traffic.